### PR TITLE
Added support for duplicate Layer and replace image #20

### DIFF
--- a/freehandrastergeoreferencer_layer.py
+++ b/freehandrastergeoreferencer_layer.py
@@ -42,7 +42,7 @@ class FreehandRasterGeoreferencerLayer(QgsPluginLayer):
 
         self.title = title
         self.filepath = filepath
-
+        self.screenExtent = screenExtent
         # set custom properties
         self.setCustomProperty("title", title)
         self.setCustomProperty("filepath", self.filepath)
@@ -292,6 +292,27 @@ class FreehandRasterGeoreferencerLayer(QgsPluginLayer):
         else:
             # all width
             self.setScale(wratio, wratio)
+
+    def replaceImage(self, filepath, title):
+        self.title = title
+        self.filepath = filepath
+
+         # set custom properties
+        self.setCustomProperty("title", title)
+        self.setCustomProperty("filepath", self.filepath)
+        self.setName(title)
+        reader = QImageReader(filepath)
+        self.image = reader.read()
+        self.repaint()
+
+    def clone(self):
+        layer = FreehandRasterGeoreferencerLayer(self.plugin, self.filepath, self.title, self.screenExtent)
+        layer.center = self.center
+        layer.rotation = self.rotation
+        layer.xScale = self.xScale
+        layer.yScale = self.yScale
+        layer.commitTransformParameters()
+        return layer
 
     def getAbsoluteFilepath(self):
         if not os.path.isabs(self.filepath):

--- a/freehandrastergeoreferencerdialog.py
+++ b/freehandrastergeoreferencerdialog.py
@@ -25,11 +25,19 @@ class FreehandRasterGeoreferencerDialog(QDialog,
     def __init__(self):
         QDialog.__init__(self)
         self.setupUi(self)
-
+        self.pushButtonAdd.clicked.connect(self.accept)
+        self.pushButtonCancel.clicked.connect(self.reject)
         self.pushButtonBrowse.clicked.connect(self.showBrowserDialog)
+        self.pushButtonReplace.clicked.connect(self.replaceImage)
 
-    def clear(self):
-        self.lineEditImagePath.setText("")
+    def clear(self, layer):
+        self.layer = layer
+        if layer is None:
+            imagepath = ""
+        else:
+            imagepath = layer.filepath
+
+        self.lineEditImagePath.setText(imagepath)
 
     def showBrowserDialog(self):
         bDir, found = QgsProject.instance().readEntry(
@@ -46,6 +54,12 @@ class FreehandRasterGeoreferencerDialog(QDialog,
             QgsProject.instance().writeEntry(utils.SETTINGS_KEY,
                                              utils.SETTING_BROWSER_RASTER_DIR,
                                              bDir)
+
+    def replaceImage(self):
+        imagepath = self.lineEditImagePath.text()
+        imagename, _ = os.path.splitext(os.path.basename(imagepath))
+        self.layer.replaceImage(imagepath, imagename)
+        self.close()
 
     def accept(self):
         result, message, details = self.validate()

--- a/freehandrastergeoreferencerdialog.ui
+++ b/freehandrastergeoreferencerdialog.ui
@@ -16,29 +16,13 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <widget class="QDialogButtonBox" name="buttonBox">
-   <property name="geometry">
-    <rect>
-     <x>80</x>
-     <y>60</y>
-     <width>371</width>
-     <height>23</height>
-    </rect>
-   </property>
-   <property name="orientation">
-    <enum>Qt::Horizontal</enum>
-   </property>
-   <property name="standardButtons">
-    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-   </property>
-  </widget>
   <widget class="QLineEdit" name="lineEditImagePath">
    <property name="geometry">
     <rect>
      <x>90</x>
      <y>20</y>
      <width>271</width>
-     <height>20</height>
+     <height>23</height>
     </rect>
    </property>
   </widget>
@@ -61,52 +45,88 @@
      <x>10</x>
      <y>20</y>
      <width>71</width>
-     <height>16</height>
+     <height>23</height>
     </rect>
+   </property>
+   <property name="layoutDirection">
+    <enum>Qt::LeftToRight</enum>
    </property>
    <property name="text">
     <string>Image path</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="pushButtonDuplicate">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>60</y>
+     <width>91</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Duplicate Layer</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="pushButtonReplace">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>260</x>
+     <y>60</y>
+     <width>91</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Replace Image</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="pushButtonAdd">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>160</x>
+     <y>60</y>
+     <width>91</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Add New</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="pushButtonCancel">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>360</x>
+     <y>60</y>
+     <width>91</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Cancel</string>
    </property>
   </widget>
  </widget>
  <tabstops>
   <tabstop>lineEditImagePath</tabstop>
   <tabstop>pushButtonBrowse</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>FreehandRasterGeoreferencer</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>FreehandRasterGeoreferencer</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>


### PR DESCRIPTION
Implemented duplicate layer and replace image on "Add button"
If you select an added image layer, "Add Button" will be able to duplicate this layer or replace the image.