### PR TITLE
Correct typo in export message bar strings

### DIFF
--- a/fhgr/export.py
+++ b/fhgr/export.py
@@ -154,13 +154,13 @@ class ExportGeorefRasterCommand:
                 )
 
             widget = QgsMessageBar.createMessage(
-                "Raster Geoferencer", "Raster exported successfully."
+                "Raster Georeferencer", "Raster exported successfully."
             )
             self.iface.messageBar().pushWidget(widget, Qgis.MessageLevel.Info, 2)
         except Exception as ex:
             QgsMessageLog.logMessage(repr(ex))
             widget = QgsMessageBar.createMessage(
-                "Raster Geoferencer",
+                "Raster Georeferencer",
                 "There was an error performing this command. "
                 "See QGIS Message log for details.",
             )


### PR DESCRIPTION
### Summary

Fixes #74

### What changed?

- Changed `Raster Geoferencer` to `Raster Georeferencer` in two `QgsMessageBar.createMessage()` calls inside `export_georef_raster()`.

### How was this tested?

- `uv run pytest` -- 25 passed, 3 skipped
- `uv run task lint` -- clean
- `uv run task format-check` -- clean