### PR TITLE
fix: correct typo Raster Geoferencer to Raster Georeferencer in export messages

### DIFF
--- a/freehandrastergeoreferencer_commands.py
+++ b/freehandrastergeoreferencer_commands.py
@@ -145,13 +145,13 @@ class ExportGeorefRasterCommand(object):
                 )
 
             widget = QgsMessageBar.createMessage(
-                "Raster Geoferencer", "Raster exported successfully."
+                "Raster Georeferencer", "Raster exported successfully."
             )
             self.iface.messageBar().pushWidget(widget, Qgis.Info, 2)
         except Exception as ex:
             QgsMessageLog.logMessage(repr(ex))
             widget = QgsMessageBar.createMessage(
-                "Raster Geoferencer",
+                "Raster Georeferencer",
                 "There was an error performing this command. "
                 "See QGIS Message log for details.",
             )


### PR DESCRIPTION
Fixes gvellut/FreehandRasterGeoreferencer#74 — corrects "Raster Geoferencer" to "Raster Georeferencer" in two user-facing message bar strings in freehandrastergeoreferencer_commands.py lines 148 and 154.

Impact: cosmetic. The typo is visible in the QGIS message bar after every export operation. No functional impact.

Gate-1(new repo) Gate-2(0 OPEN PRs) Gate-3(1 commit)